### PR TITLE
Allow to view the full evaluation

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -134,11 +134,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 132,
               "column": 20
             },
             "end": {
-              "line": 99,
+              "line": 135,
               "column": 21
             }
           },
@@ -154,11 +154,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 104,
+              "line": 140,
               "column": 20
             },
             "end": {
-              "line": 106,
+              "line": 142,
               "column": 21
             }
           },
@@ -173,11 +173,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 111,
+              "line": 147,
               "column": 20
             },
             "end": {
-              "line": 113,
+              "line": 149,
               "column": 21
             }
           },
@@ -192,11 +192,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 118,
+              "line": 154,
               "column": 20
             },
             "end": {
-              "line": 120,
+              "line": 156,
               "column": 21
             }
           },
@@ -211,11 +211,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 125,
+              "line": 161,
               "column": 20
             },
             "end": {
-              "line": 127,
+              "line": 163,
               "column": 21
             }
           },
@@ -230,11 +230,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 129,
+              "line": 165,
               "column": 20
             },
             "end": {
-              "line": 132,
+              "line": 168,
               "column": 21
             }
           },
@@ -250,11 +250,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 134,
+              "line": 170,
               "column": 20
             },
             "end": {
-              "line": 137,
+              "line": 173,
               "column": 21
             }
           },
@@ -271,11 +271,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 145,
+              "line": 181,
               "column": 12
             },
             "end": {
-              "line": 147,
+              "line": 183,
               "column": 13
             }
           },
@@ -288,11 +288,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 149,
+              "line": 185,
               "column": 12
             },
             "end": {
-              "line": 151,
+              "line": 187,
               "column": 13
             }
           },
@@ -318,11 +318,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 153,
+              "line": 189,
               "column": 12
             },
             "end": {
-              "line": 159,
+              "line": 195,
               "column": 13
             }
           },
@@ -335,11 +335,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 161,
+              "line": 197,
               "column": 12
             },
             "end": {
-              "line": 173,
+              "line": 209,
               "column": 13
             }
           },
@@ -349,6 +349,51 @@
               "name": "request"
             }
           ]
+        },
+        {
+          "name": "_getClassForEvaluation",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 211,
+              "column": 12
+            },
+            "end": {
+              "line": 217,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "evaluation"
+            },
+            {
+              "name": "selected"
+            }
+          ]
+        },
+        {
+          "name": "_textWillOverflow",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 219,
+              "column": 12
+            },
+            "end": {
+              "line": 229,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text"
+            }
+          ]
         }
       ],
       "staticMethods": [],
@@ -356,11 +401,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 86,
+          "line": 122,
           "column": 8
         },
         "end": {
-          "line": 174,
+          "line": 230,
           "column": 9
         }
       },
@@ -373,11 +418,11 @@
           "description": "The provider of the course, e.g. \"openHPI\"",
           "sourceRange": {
             "start": {
-              "line": 104,
+              "line": 140,
               "column": 20
             },
             "end": {
-              "line": 106,
+              "line": 142,
               "column": 21
             }
           },
@@ -389,11 +434,11 @@
           "description": "The ID of the course in the provider's system",
           "sourceRange": {
             "start": {
-              "line": 111,
+              "line": 147,
               "column": 20
             },
             "end": {
-              "line": 113,
+              "line": 149,
               "column": 21
             }
           },
@@ -405,11 +450,11 @@
           "description": "The number of items shown per page",
           "sourceRange": {
             "start": {
-              "line": 118,
+              "line": 154,
               "column": 20
             },
             "end": {
-              "line": 120,
+              "line": 156,
               "column": 21
             }
           },
@@ -421,11 +466,11 @@
           "description": "The number of ratings in general",
           "sourceRange": {
             "start": {
-              "line": 125,
+              "line": 161,
               "column": 20
             },
             "end": {
-              "line": 127,
+              "line": 163,
               "column": 21
             }
           },
@@ -664,7 +709,7 @@
               "column": 12
             },
             "end": {
-              "line": 258,
+              "line": 262,
               "column": 13
             }
           },
@@ -685,7 +730,7 @@
           "column": 8
         },
         "end": {
-          "line": 259,
+          "line": 263,
           "column": 9
         }
       },
@@ -919,16 +964,19 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 172,
+              "line": 173,
               "column": 12
             },
             "end": {
-              "line": 174,
+              "line": 175,
               "column": 13
             }
           },
           "metadata": {},
-          "params": []
+          "params": [],
+          "return": {
+            "type": "void"
+          }
         },
         {
           "name": "ready",
@@ -936,11 +984,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 176,
+              "line": 177,
               "column": 12
             },
             "end": {
-              "line": 178,
+              "line": 179,
               "column": 13
             }
           },
@@ -953,11 +1001,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 180,
+              "line": 181,
               "column": 12
             },
             "end": {
-              "line": 182,
+              "line": 183,
               "column": 13
             }
           },
@@ -977,11 +1025,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 184,
+              "line": 185,
               "column": 12
             },
             "end": {
-              "line": 186,
+              "line": 187,
               "column": 13
             }
           },
@@ -1001,11 +1049,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 188,
+              "line": 189,
               "column": 12
             },
             "end": {
-              "line": 195,
+              "line": 196,
               "column": 13
             }
           },
@@ -1031,7 +1079,7 @@
           "column": 8
         },
         "end": {
-          "line": 196,
+          "line": 197,
           "column": 9
         }
       },

--- a/mammooc-rating-widget.html
+++ b/mammooc-rating-widget.html
@@ -1,0 +1,1 @@
+<link rel="import" href="src/mammooc-rating-widget.html">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,9 +2191,9 @@
       }
     },
     "clean-css": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.8.tgz",
-      "integrity": "sha1-BhRVsklKdQrJj0bY1euxfGeeqdE=",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+      "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
       "dev": true,
       "requires": {
         "source-map": "0.5.6"
@@ -2806,9 +2806,9 @@
       "dev": true
     },
     "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true
     },
     "debug": {
@@ -2868,14 +2868,6 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "delayed-stream": {
@@ -3337,9 +3329,9 @@
       }
     },
     "eslint": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.1.tgz",
-      "integrity": "sha1-hJgEE2lT6+NmeC+fhhHiy9G1RoE=",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
+      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
@@ -4213,14 +4205,6 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "got": {
@@ -4297,14 +4281,6 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "growl": {
@@ -4516,13 +4492,13 @@
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
-        "clean-css": "4.1.8",
+        "clean-css": "4.1.9",
         "commander": "2.11.0",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.1.0"
+        "uglify-js": "3.1.1"
       },
       "dependencies": {
         "commander": {
@@ -5735,12 +5711,6 @@
             "pinkie-promise": "2.0.1"
           }
         },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
         "replace-ext": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
@@ -6679,9 +6649,9 @@
       }
     },
     "polymer-cli": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/polymer-cli/-/polymer-cli-1.5.4.tgz",
-      "integrity": "sha512-qVMGshUXfEmcYD0cDSqf23H2CmSRE8MpyxYkrHOhXCZJrXgVk8M5ks7xYFq9kkg726txMIbFhzLqTvXZQV/+gg==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/polymer-cli/-/polymer-cli-1.5.5.tgz",
+      "integrity": "sha512-pDsAY2bwnoFHe/Iuh8KcxD18goSmpH3/z1q8Ia9vJcdh3NNN+BSpJW0uy5fqut2gfalG/RotsuVDBUhGrNTl5w==",
       "dev": true,
       "requires": {
         "@types/babel-core": "6.25.2",
@@ -6728,7 +6698,7 @@
         "polymer-build": "2.0.0",
         "polymer-linter": "2.0.3",
         "polymer-project-config": "3.4.0",
-        "polyserve": "0.20.0",
+        "polyserve": "0.22.1",
         "request": "2.79.0",
         "rimraf": "2.6.2",
         "semver": "5.4.1",
@@ -6809,22 +6779,10 @@
             "through": "2.3.8"
           }
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
         "mute-stream": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
           "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "onetime": {
@@ -6894,19 +6852,20 @@
       }
     },
     "polyserve": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.20.0.tgz",
-      "integrity": "sha512-i99n2lHz2Xuje7dRZAFx4DhLPLhZyDiiBz6QLaq0TmWEjqoDYsf/EFikemD2SEz8Cf4Q03Tn0E6EZ742KuXGhw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.22.1.tgz",
+      "integrity": "sha512-P7skbXsIIt97l9ndIdCvVgmaVdXq2cuWUa5ivp3I8ZNDq2KGpWUKxzTl9vFe+gdVyfyKmgV1df59CNiNf2RlSQ==",
       "dev": true,
       "requires": {
         "@types/assert": "0.0.29",
         "@types/babel-core": "6.25.2",
+        "@types/babylon": "6.16.2",
         "@types/compression": "0.0.33",
         "@types/content-type": "1.1.1",
         "@types/express": "4.0.37",
         "@types/mime": "0.0.29",
         "@types/mz": "0.0.29",
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.30",
         "@types/opn": "3.0.28",
         "@types/parse5": "2.2.34",
         "@types/pem": "1.9.2",
@@ -6924,6 +6883,7 @@
         "babel-plugin-transform-es2015-for-of": "6.23.0",
         "babel-plugin-transform-es2015-function-name": "6.24.1",
         "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-plugin-transform-es2015-object-super": "6.24.1",
         "babel-plugin-transform-es2015-parameters": "6.24.1",
         "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
@@ -6933,6 +6893,8 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
+        "babylon": "6.18.0",
+        "browser-capabilities": "0.2.0",
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
         "compression": "1.7.0",
@@ -6948,16 +6910,16 @@
         "parse5": "2.2.3",
         "pem": "1.11.0",
         "polymer-build": "2.0.0",
+        "requirejs": "2.3.5",
         "resolve": "1.4.0",
         "send": "0.14.2",
-        "spdy": "3.4.7",
-        "ua-parser-js": "0.7.14"
+        "spdy": "3.4.7"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-          "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ==",
+          "version": "8.0.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.30.tgz",
+          "integrity": "sha512-IaQtG3DWe9gRsmk1DqNnYyRVjGDVcBdZywkRVF2f62Boe8XKmlR7lNcwC6pk4V4W8nk+Zu+vdGMsOdRTDj1JPA==",
           "dev": true
         },
         "debug": {
@@ -8821,9 +8783,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.0.tgz",
-      "integrity": "sha512-PGUXuTJ5AkrfPsyg0L9/LD+BWYm9feVngbWpW5bg7Q3B7hqDM3xz00tNby4yY0CqjrLTF6CP9wpb/aNITRuSXg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.1.tgz",
+      "integrity": "sha512-f7DpmEgt/RYAKzQzcfahn3JYZHobDwTZCa8oixC7pweVGEIizTX2kTYdNWcdk00xsMJqUhI8RDAa9HXHXGhNxA==",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
@@ -9728,22 +9690,10 @@
             "through": "2.3.8"
           }
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
         "mute-stream": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
           "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "onetime": {
@@ -9785,7 +9735,7 @@
         "cli-table": "0.3.1",
         "cross-spawn": "5.1.0",
         "dargs": "5.1.0",
-        "dateformat": "2.0.0",
+        "dateformat": "2.2.0",
         "debug": "2.6.8",
         "detect-conflict": "1.0.1",
         "error": "7.0.2",
@@ -9840,12 +9790,6 @@
             "pify": "2.3.0",
             "strip-bom": "3.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
         },
         "minimist": {
           "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": "^4.7.1",
+    "eslint": "^4.7.2",
     "eslint-plugin-html": "^3.1.0",
     "htmlhint": "^0.9.13",
     "polymer-bundler": "^3.0.0",
-    "polymer-cli": "^1.4.0",
+    "polymer-cli": "^1.5.5",
     "web-component-tester": "^6.2.0"
   },
   "scripts": {

--- a/polymer.json
+++ b/polymer.json
@@ -1,5 +1,5 @@
 {
-  "entrypoint": "src/mammooc-rating-widget.html",
+  "entrypoint": "mammooc-rating-widget.html",
   "sources": [
     "src/**/*",
     "bower.json"

--- a/src/mammooc-course-evaluation-form.html
+++ b/src/mammooc-course-evaluation-form.html
@@ -250,12 +250,16 @@ Example:
                 if (!this.loggedIn) {
                     return;
                 }
-                this.shadowRoot.querySelector('#profile_image').src = result.user.profile_picture;
-                this.shadowRoot.querySelector('#profile_name').innerHTML = result.user.name;
-                this.shadowRoot.querySelector('#description').value = result.evaluation.description;
-                this.shadowRoot.querySelector('#stars').value = result.evaluation.rating;
-                this.shadowRoot.querySelector('#status').selected = result.evaluation.course_status;
-                this.shadowRoot.querySelector('#anonymously').checked = result.evaluation.rated_anonymously;
+                if (result.user) {
+                    this.shadowRoot.querySelector('#profile_image').src = result.user.profile_picture;
+                    this.shadowRoot.querySelector('#profile_name').innerHTML = result.user.name;
+                }
+                if (result.evaluation) {
+                    this.shadowRoot.querySelector('#description').value = result.evaluation.description;
+                    this.shadowRoot.querySelector('#stars').value = result.evaluation.rating;
+                    this.shadowRoot.querySelector('#status').selected = result.evaluation.course_status;
+                    this.shadowRoot.querySelector('#anonymously').checked = result.evaluation.rated_anonymously;
+                }
             }
         }
 

--- a/src/mammooc-course-evaluation.html
+++ b/src/mammooc-course-evaluation.html
@@ -30,12 +30,16 @@ Example:
                 overflow-y: scroll;
             }
 
-            .evaluation-card {
+            .evaluation-card, .evaluation-card-fixed {
                 min-height: 50px;
                 padding-bottom: 3px;
             }
 
-            .evaluation-card img {
+            .evaluation-card {
+                cursor: pointer;
+            }
+
+            .evaluation-card img, .evaluation-card-fixed img {
                 float: left;
                 width: 50px;
                 height: 50px;
@@ -44,14 +48,43 @@ Example:
                 border: 1px solid var(--mammooc-rating-widget-secondary-color, #9999);
             }
 
-            .evaluation-content {
-                overflow: auto;
-            }
-
-            .evaluation-content {
+            .evaluation-content-short {
                 white-space: nowrap;
                 text-overflow: ellipsis;
                 overflow: hidden;
+            }
+
+            .evaluation-content-long {
+                display: none;
+            }
+
+            .evaluation-card:hover .evaluation-header::after {
+                content: ' [+]';
+                color: var(--mammooc-rating-widget-secondary-color, #9999);
+            }
+
+            .evaluation-card.expanded {
+                padding-bottom: 15px;
+            }
+
+            .evaluation-card.expanded:hover .evaluation-header::after {
+                content: '';
+            }
+
+            .evaluation-card.expanded .evaluation-content-long {
+                display: flex;
+                white-space: normal;
+                text-overflow: initial;
+                overflow: visible;
+            }
+
+            .evaluation-card.expanded .evaluation-content-short {
+                display: none;
+            }
+
+            .evaluation-card.expanded:hover .evaluation-header::after {
+                content: ' [–]';
+                color: var(--mammooc-rating-widget-secondary-color, #9999);
             }
 
             .heading {
@@ -67,12 +100,15 @@ Example:
         </div>
         <div class="evaluations">
             <iron-scroll-threshold id="scrollThreshold" on-lower-threshold="_loadMoreData">
-              <iron-list scroll-target="scrollThreshold" items="[[_evaluations]]" as="evaluation">
+              <iron-list scroll-target="scrollThreshold" items="[[_evaluations]]" as="evaluation" selection-enabled multi-selection>
                 <template>
-                  <div class="evaluation-card">
-                  <img src="{{evaluation.user_profile_picture}}" alt="mammooc profile image"/>
-                  <div><b>{{evaluation.user_name}}</b> <flexible-rating value="{{evaluation.rating}}" disabled></flexible-rating></div>
-                  <div class="evaluation-content">{{evaluation.description}}</div>
+                  <div class$="{{_getClassForEvaluation(evaluation, selected)}}">
+                      <img src="{{evaluation.user_profile_picture}}" alt="mammooc profile image"/>
+                      <div class="evaluation-header">
+                          <flexible-rating value="{{evaluation.rating}}" disabled></flexible-rating> <b>{{evaluation.user_name}}</b>
+                      </div>
+                      <div class="evaluation-content-short">{{evaluation.description}}</div>
+                      <div class="evaluation-content-long">{{evaluation.description}}</div>
                   </div>
                   <br />
                 </template>
@@ -171,6 +207,27 @@ Example:
                     this.push('_evaluations', newEvaluations[i]);
 
                 this.$.scrollThreshold.clearTriggers();
+            }
+
+            _getClassForEvaluation(evaluation, selected) {
+                if (!this._textWillOverflow(evaluation.description)) {
+                    return 'evaluation-card-fixed';
+                }
+                else {
+                    return selected ? 'evaluation-card expanded' : 'evaluation-card';
+                }
+            }
+
+            _textWillOverflow(text) {
+                const tag = document.createElement("div");
+                tag.className = "evaluation-content-short";
+                tag.innerHTML = text;
+
+                this.shadowRoot.querySelector('.evaluations').appendChild(tag);
+                const result = tag.clientWidth < tag.scrollWidth;
+                this.shadowRoot.querySelector('.evaluations').removeChild(tag);
+
+                return result;
             }
         }
 

--- a/src/mammooc-course-evaluation.html
+++ b/src/mammooc-course-evaluation.html
@@ -212,15 +212,14 @@ Example:
             _getClassForEvaluation(evaluation, selected) {
                 if (!this._textWillOverflow(evaluation.description)) {
                     return 'evaluation-card-fixed';
-                }
-                else {
+                } else {
                     return selected ? 'evaluation-card expanded' : 'evaluation-card';
                 }
             }
 
             _textWillOverflow(text) {
-                const tag = document.createElement("div");
-                tag.className = "evaluation-content-short";
+                const tag = document.createElement('div');
+                tag.className = 'evaluation-content-short';
                 tag.innerHTML = text;
 
                 this.shadowRoot.querySelector('.evaluations').appendChild(tag);

--- a/src/mammooc-rating-widget.html
+++ b/src/mammooc-rating-widget.html
@@ -169,6 +169,7 @@ Custom property | Description | Default
 
             /**
              *  Request the current evaluations present on mammooc and update the visuals accordingly.
+             *  @returns {void}
              */
             updateEvaluations() {
                 this.$.evaluationsXHR.generateRequest();


### PR DESCRIPTION
This PR adds the ability to toggle the full length of evaluations. Except the fact that I swapped the stars with the name of the evaluator, you first won't notice any difference at all. As soon as you start hovering over the evaluations, a `[+]` will appear behind the name of reviewers with a longer text and your mouse pointer will change to a hand (everywhere on the evaluation [e.g. on the stars, the name, the one-line preview,...]). Once you click, the full text is visible and the `[+]` is changed to `[-]` (which will re-collapse the text again if clicked). The `[+]` and the mouse pointer is only shown for evaluations that might be expanded. For all others, you won't see any of these optical hints and nothing happens when clicking anywhere.

**See my screenshots below:**

Collapsed evaluation:
<img width="533" alt="bildschirmfoto 2017-09-24 um 02 11 22" src="https://user-images.githubusercontent.com/7300329/30778147-2692301e-a0ce-11e7-846e-9e97d975c5c4.png">

Expanded evaluation:
<img width="526" alt="bildschirmfoto 2017-09-24 um 02 11 35" src="https://user-images.githubusercontent.com/7300329/30778149-26b9ef14-a0ce-11e7-8b13-29ab6c405aa9.png">